### PR TITLE
chore: update copyright year to 2025 and remove branding

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2020 Prateek Choudhary
+Copyright (c) 2025 Prateek Choudhary
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -123,7 +123,7 @@
                 Copyright © {{ site.time | date: "%Y" }} {{ site.name }}
             </div>
             <div class="col-md-6 col-sm-6 text-center text-lg-right">
-                <a target="_blank" href="https://www.wowthemes.net/mediumish-free-jekyll-template/">Mediumish Jekyll Theme</a> by WowThemes.net
+                Built with Jekyll
             </div>
         </div>
     </div>

--- a/assets/css/screen.css
+++ b/assets/css/screen.css
@@ -1,7 +1,5 @@
 /*
-Template Name: Mediumish
-Copyright: Sal, WowThemes.net, https://www.wowthemes.net
-License: https://www.wowthemes.net/freebies-license/
+Main stylesheet
 */
 @media screen and (min-width:1500px) {
     html { font-size:18px; } /* Increase the font size on higher resolutions */

--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,4 @@
-# Mediumish Jekyll Theme - Change Log
+# Change Log
 
 ## 2019-05-16, v1.0.36
 - docker-composer.yml


### PR DESCRIPTION
## Summary
- Updated copyright year from 2020 to 2025 in LICENSE file
- Replaced theme credit with generic "Built with Jekyll" text

## Test plan
- [x] Verified all Mediumish branding has been removed
- [x] Confirmed copyright year is updated to 2025
- [ ] Test Jekyll build locally to ensure no visual/functional issues