### PR TITLE
fix: replace deprecated Sass @import with @use rule

### DIFF
--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -3,11 +3,10 @@
 # Change this file for any custom CSS.
 ---
 
+// Import partials from `sass_dir` (defaults to `_sass`)
+@use "syntax";
+
 /* We need to add display:inline in order to align the '>>' of the 'read more' link */
 .post-excerpt p {
 	display:inline;
 }
-
-// Import partials from `sass_dir` (defaults to `_sass`)
-@import
-	"syntax";


### PR DESCRIPTION
## Summary
- Replace deprecated `@import` with `@use` rule in main.scss
- Move `@use` statement before other CSS rules to comply with Sass syntax requirements

## Test plan
- [x] Verified Jekyll build runs without deprecation warnings
- [x] Confirmed no syntax errors after moving @use rule to top
- [x] Test that styles are applied correctly in the browser